### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Also make sure that you are using the correct version of dnSpy that matches the 
 The plugin **will not work** with certain mismatched versions due to strong-name signing of some dependencies.
 
 ### Developing
-To test the extension, you can launch dnSpy with the `--extension-directory {direcory}` argument, where `{directory}` is the build directory (ie. `.../bin/Debug/netcoreapp3.1`).
+To test the extension, you can launch dnSpy with the `--extension-directory {directory}` argument, where `{directory}` is the build directory (ie. `.../bin/Debug/netcoreapp3.1`).
 JetBrains Rider supports launch profiles, allowing you to specify dnSpy as the executable to start. This means you can launch and debug the extension from within the IDE.
 
 Due to how the .NET Framework does assembly resolving, this method may only work on .NET Core.


### PR DESCRIPTION
Change "direcory" to "directory":
> To test the extension, you can launch dnSpy with the `--extension-directory {direcory}` argument, where `{directory}` is the build directory (ie. `.../bin/Debug/netcoreapp3.1`).

> To test the extension, you can launch dnSpy with the `--extension-directory {directory}` argument, where `{directory}` is the build directory (ie. `.../bin/Debug/netcoreapp3.1`).